### PR TITLE
OPS-108 do not use the parameters -u and -g for varnish 4.1

### DIFF
--- a/libraries/varnish_instance.rb
+++ b/libraries/varnish_instance.rb
@@ -36,6 +36,7 @@ class Chef
                                         'thread_pool_max' => '500',
                                         'thread_pool_timeout' => '300' }
       attribute :path_to_secret, kind_of: String, default: '/etc/varnish/secret'
+      attribute :version, kind_of: String, default: '4.0'
     end
   end
 
@@ -59,7 +60,10 @@ class Chef
         varnish_args << "-a #{new_resource.listen_address}:#{new_resource.listen_port}"
         varnish_args << "-f #{new_resource.path_to_vcl}"
         varnish_args << "-T #{new_resource.admin_listen_address}:#{new_resource.admin_listen_port}"
-        varnish_args << "-u #{new_resource.user} -g #{new_resource.group}"
+        if new_resource.version == '4.0'
+          # varnish_args << "-u #{new_resource.user} -g #{new_resource.group}"
+          varnish_args << "-u #{new_resource.user} -g #{new_resource.group}"
+        end
         varnish_args << "-t #{new_resource.ttl}"
         varnish_args << "-n #{new_resource.instance_name}"
         if new_resource.storage == 'file'

--- a/libraries/varnish_instance.rb
+++ b/libraries/varnish_instance.rb
@@ -61,7 +61,7 @@ class Chef
         varnish_args << "-f #{new_resource.path_to_vcl}"
         varnish_args << "-T #{new_resource.admin_listen_address}:#{new_resource.admin_listen_port}"
         if new_resource.version == '4.0'
-          # varnish_args << "-u #{new_resource.user} -g #{new_resource.group}"
+          # The following parameters were removed from varnish 4.1 When using them, the execution will exit with error.
           varnish_args << "-u #{new_resource.user} -g #{new_resource.group}"
         end
         varnish_args << "-t #{new_resource.ttl}"

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'cookbooks@chef.io'
 license 'Apache 2.0'
 description 'Installs and configures varnish'
 #version '2.1.0'
-version '99.0.8'
+version '99.0.9'
 
 recipe 'varnish', 'Installs and configures varnish'
 recipe 'varnish::repo', 'Adds the official varnish project repository'


### PR DESCRIPTION
This is using attribute version in the varnish_instance to decide, if the command line options for varnish 4.1 need to be used.
In varnish 4.1 the parameters -u and -g are removed and causes varnishd to exit with code 1
